### PR TITLE
Fixed OS detection for Python imports

### DIFF
--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -8,7 +8,10 @@
 import sys
 import os
 
-sys.path.append('C:\\Python27\\lib\\site-packages')
+if os.name == "posix":
+    sys.path.append('/usr/lib/python2.7/dist-packages')
+else:
+    sys.path.append('C:\\Python27\\lib\\site-packages')
 
 import hashlib
 import traceback


### PR DESCRIPTION
Hello,
Just a simple change to allow the plugin to find its Python module when executed on Linux.