### PR TITLE
Update intezer_analyze_gh_community.py

### DIFF
--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -8,11 +8,18 @@
 import sys
 import os
 
-if os.name == "posix":
+if (os.name == "Posix") and (("Linux") in os.uname()):
     sys.path.append('/usr/lib/python2.7/dist-packages')
     sys.path.append('/usr/local/lib/python2.7/dist-packages')
-else:
+elif ("Darwin") in os.uname():
+    sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages')
+    sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/site-python')
+    sys.path.append('/Library/Python/2.7/site-packages')
+    sys.path.append(os.path.expanduser('~')+'/Library/Python/2.7/lib/python/site-packages')
+elif os.name == "nt":
     sys.path.append('C:\\Python27\\lib\\site-packages')
+else:
+    print('Whelp, something went wrong.')
 
 import hashlib
 import traceback


### PR DESCRIPTION
This should help resolve some of the `site-packages` pathing issues that some users are encountering on Debian, macOS, and Windows.

If memory serves, there's a difference between the way Debian (and its derivative distros) treat `site-packages` (i.e. the path is `dist-packages`, as reflected in the script, but `site-packages` on other flavors), which is why there's a test "Posix" and "Linux" in the initial `if` statement. Perhaps someone smarter than I can come up with a way to test for Linux distro.