### PR TITLE
Add openjdk:11-jdk-slim docker support

### DIFF
--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -11,6 +11,10 @@ import sys
 if (os.name == "Posix") and (("Linux") in os.uname()):
     sys.path.append('/usr/lib/python2.7/dist-packages')
     sys.path.append('/usr/local/lib/python2.7/dist-packages')
+elif os.name == "java":
+    sys.path.append('/usr/lib/python2.7/dist-packages')
+    sys.path.append('/usr/local/lib/python2.7/dist-packages')
+    sys.path.append('/usr/local/lib/python2.7/site-packages')
 elif ("Darwin") in os.uname():
     sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages')
     sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/site-python')


### PR DESCRIPTION
Add support for my docker Ghidra setup.
Image uses openjdk:11-jdk-slim and I disovered I needed to configure python path with elif os.name == "java":

Matt