### PR TITLE
Change order of sys path appends to check java last.

### DIFF
--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -11,10 +11,6 @@ import sys
 if (os.name == "Posix") and (("Linux") in os.uname()):
     sys.path.append('/usr/lib/python2.7/dist-packages')
     sys.path.append('/usr/local/lib/python2.7/dist-packages')
-elif os.name == "java":
-    sys.path.append('/usr/lib/python2.7/dist-packages')
-    sys.path.append('/usr/local/lib/python2.7/dist-packages')
-    sys.path.append('/usr/local/lib/python2.7/site-packages')
 elif ("Darwin") in os.uname():
     sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages')
     sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/site-python')
@@ -22,6 +18,10 @@ elif ("Darwin") in os.uname():
     sys.path.append(os.path.expanduser('~') + '/Library/Python/2.7/lib/python/site-packages')
 elif os.name == "nt" or ("windows") in java.lang.System.getProperty("os.name").lower():
     sys.path.append('C:\\Python27\\lib\\site-packages')
+elif os.name == "java":
+    sys.path.append('/usr/lib/python2.7/dist-packages')
+    sys.path.append('/usr/local/lib/python2.7/dist-packages')
+    sys.path.append('/usr/local/lib/python2.7/site-packages')
 else:
     print('Whelp, something went wrong.')
 


### PR DESCRIPTION
Changing the order of the `os.name` and `os.uname()` checks so that the check for plain java is last should fix all of the various problems people have reported with the requests module not being found.

In a macOS environment, the check for "java" returns true and the sys path is adjusted incorrectly for macOS and the if statement is then exited before the macOS changes can be made.

This change is tested in:
Ghidra 10.1.1.
macOS 11.6.1
Jython 2.7.2

From the Python interpreter in Ghidra:
```
Python Interpreter for Ghidra
Based on Jython version 2.7.2 (v2.7.2:925a3cc3b49d, Mar 21 2020, 10:03:58)
[Java HotSpot(TM) 64-Bit Server VM (Oracle Corporation)]
```

If you take each of the conditions and paste them into the Python interpreter inside Ghidra, the problem is clear:
```
>>> import os
>>> import sys
>>> (os.name == "Posix") and (("Linux") in os.uname())
False
>>> os.name == "java"
True
>>> ("Darwin") in os.uname()
True
>>> os.name == "nt" or ("windows") in java.lang.System.getProperty("os.name").lower()
False
>>> os.name
PyShadowString('java', 'posix')
>>> os.uname()
('Darwin', 'example.com', '20.6.0', 'Darwin Kernel Version 20.6.0: Wed Nov 10 22:23:07 PST 2021; root:xnu-7195.141.14~1/RELEASE_X86_64', 'x86_64')
```

The change in order means that the more specific checks are done first. If they are matched, the if statement exits. The generic "java" is checked last. If that fails then it prints the error message.