### PR TITLE
Adjust path search and document requests dependency. Fixes #18 Fixes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ https://www.intezer.com/blog/intezer-analyze/community-ghidra-plugin-is-here/
 
 ![alt text](https://github.com/intezer/analyze-community-ghidra-plugin/blob/master/media/ghidra_community.gif)
 
+**Dependencies**
+
+This plugin requires the Python requests HTTP library. The plugin checks its environment for the type of OS and then chooses an appropriate syntax for extending the PATH environment variable to include the location where requests is installed. On Linux and macOS, requests is recommended to be installed only for the user running Ghidra since Jython can only use Python 2.7 packages and that version of Python is past its end of life. A minimal install that is maintainable is to use `get-pip.py` and then install requests:
+
+```
+wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
+python2 get-pip.py --user
+pip2 install --user requests
+```
+
 **Installation**
 1. Clone the repo.
 

--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -8,9 +8,10 @@
 import os
 import sys
 
-if (os.name == "Posix") and (("Linux") in os.uname()):
+if (os.name == "Posix" or os.name.getshadow() == "posix") and (("Linux") in os.uname()):
     sys.path.append('/usr/lib/python2.7/dist-packages')
     sys.path.append('/usr/local/lib/python2.7/dist-packages')
+    sys.path.append(os.path.expanduser('~') + '/.local/lib/python2.7/site-packages')
 elif ("Darwin") in os.uname():
     sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages')
     sys.path.append('/System/Library/Frameworks/Python.framework/Versions/2.7/lib/site-python')


### PR DESCRIPTION
I have added documentation for installing pip and requests for just the user running Ghidra so to contain where Python 2 packages are installed. This closes an issue and should prevent anyone else opening a new issue about `ImportError: No module named requests`. I have tested this on macOS and Ubuntu 22.04 LTS. I also adjusted the os name search process for Linux. The test used was returning `False` on this Ubuntu. I noticed that `os.name` returns a special Jython object `PyShadowString`. According to the documentation, `os.name` should return a string `java` in Jython, but in other implementations of Python, it would return `posix`. Calling the `.getshadow()` method on the object returns the expected string. Here is the relevant section of the Jython documentation:

https://www.javadoc.io/static/org.python/jython-standalone/2.7.2b2/org/python/core/PyShadowString.html