### PR TITLE
Adjust OS detection for Linux. Fixes #29

### DIFF
--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -8,7 +8,7 @@
 import os
 import sys
 
-if (os.name == "Posix") and (("Linux") in os.uname()):
+if (os.name == "Posix" or os.name.getshadow() == "posix") and (("Linux") in os.uname()):
     sys.path.append('/usr/lib/python2.7/dist-packages')
     sys.path.append('/usr/local/lib/python2.7/dist-packages')
 elif ("Darwin") in os.uname():


### PR DESCRIPTION
I noticed that `os.name` returns a special Jython object `PyShadowString`. According to the documentation, `os.name` should return a string `java` in Jython, but in other implementations of Python, it would return `posix`. Calling the `.getshadow()` method on the object returns the expected string. Here is the relevant section of the Jython documentation:

https://www.javadoc.io/static/org.python/jython-standalone/2.7.2b2/org/python/core/PyShadowString.html