### PR TITLE
Minor improvements

### DIFF
--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -1,6 +1,6 @@
 # Plugin for Intezer Analyze in Ghidra (python 2.7 - jython)
 # @author
-# @category Examples.Python
+# @category Detection
 # @keybinding
 # @menupath
 # @toolbar

--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -284,10 +284,10 @@ class IntezerAnalyzePlugin():
             print(MESSAGES['file_not_exists'])
             return
 
-        print(">>> Program Info:\n" \
-              ">>>\t%s:\n" \
-              "\t%s_%s\n" \
-              "\t(%s)\n" \
+        print(">>> Program Info:\n"
+              ">>>\t%s:\n"
+              "\t%s_%s\n"
+              "\t(%s)\n"
               "\t%s" % (
                   program_name, language_id, compiler_spec_id, creation_date, path))
 

--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -224,8 +224,7 @@ class CodeIntelligenceHelper:
     def write_xml_file(self, functions_map, is_partial_result):
 
         def prettify(elem):
-            """Return a pretty-printed XML string for the Element.
-            """
+            """Return a pretty-printed XML string for the Element."""
             rough_string = ElementTree.tostring(elem, 'utf-8')
             reparsed = minidom.parseString(rough_string)
             return reparsed.toprettyxml(indent="  ")


### PR DESCRIPTION
This PR makes the following minor improvements:

 - Change Script Manager category from `Examples.Python` to a more appropriate category, `Detection`.
 - Fix pydocstyle: [D200](http://www.pydocstyle.org/en/stable/error_codes.html), One-line docstring should fit on one line with quotes (found 2)
 - Fix pycodestyle: [E502](https://pycodestyle.pycqa.org/en/stable/intro.html#error-codes), the backslash is redundant between brackets