### PR TITLE
Prepare for requests 2.28.0 dropping Python 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ https://www.intezer.com/blog/intezer-analyze/community-ghidra-plugin-is-here/
 
 ## Dependencies
 
-This plugin requires the Python requests HTTP library at version 2.27.1 or newer. The plugin checks its environment for the type of OS and then chooses an appropriate syntax for extending the PATH environment variable to include the location where requests is installed. On Linux and macOS, requests is recommended to be installed only for the user running Ghidra since Jython can only use Python 2.7 packages and that version of Python is past its end of life. A minimal install that is maintainable is to use `get-pip.py` and then install requests:
+This plugin requires the Python requests HTTP library at version 2.27.1 or newer, but not the 2.28 branch which has dropped support for Python 2 completely. The plugin checks its environment for the type of OS and then chooses an appropriate syntax for extending the PATH environment variable to include the location where requests is installed. On Linux and macOS, requests is recommended to be installed only for the user running Ghidra since Jython can only use Python 2.7 packages and that version of Python is past its end of life. A minimal install that is maintainable is to use `get-pip.py` and then install requests:
 
 ```
 wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
 python2 get-pip.py --user
 pip2 install --user requests
 ```
+
+## Ghidra Version
+
+This plugin is tested and working on Ghidra 10.1 branch up to 10.1.4.
 
 ## Installation
 

--- a/intezer_analyze_gh_community.py
+++ b/intezer_analyze_gh_community.py
@@ -36,8 +36,9 @@ from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import SubElement
 from xml.dom import minidom
 
-if StrictVersion(requests.__version__) < StrictVersion("2.27.1"):
-    print('Dependency not met: requests 2.27.1 or newer')
+req_ver = StrictVersion(requests.__version__)
+if req_ver < StrictVersion("2.27.1") or req_ver >= StrictVersion("2.28.0"):
+    print('Dependency not met: requests 2.27.1 or newer, but not 2.28 which does not support Python 2.')
     sys.exit(1)
 
 VERSION = '0.1'


### PR DESCRIPTION
See this issue in the `requests` repo for more information:

https://github.com/psf/requests/issues/6023